### PR TITLE
fix: circular dependency problem

### DIFF
--- a/src/Grammars/BNF.ts
+++ b/src/Grammars/BNF.ts
@@ -21,7 +21,7 @@ RULE_CHAR ::= RULE_LETTER | RULE_DIGIT | "_" | "-"
 
 import { findChildrenByType } from '../SemanticHelpers';
 
-import { IRule, Parser as _Parser, IToken } from '..';
+import { IRule, Parser as _Parser, IToken } from '../Parser';
 
 namespace BNF {
   export const RULES: IRule[] = [

--- a/src/Grammars/Custom.ts
+++ b/src/Grammars/Custom.ts
@@ -18,8 +18,8 @@
 // RULE_S	::=	#x9 | #xA | #xD | #x20
 // Comment	::=	'/*' ( [^*] | '*'+ [^*/] )* '*'* '*/'
 
-import { IRule, Parser as _Parser, IToken, TokenError } from '..';
-import { findRuleByName } from '../Parser';
+import { TokenError } from '../TokenError';
+import { IRule, Parser as _Parser, IToken, findRuleByName } from '../Parser';
 
 namespace BNF {
   export const RULES: IRule[] = [

--- a/src/Grammars/W3CEBNF.ts
+++ b/src/Grammars/W3CEBNF.ts
@@ -18,8 +18,7 @@
 // RULE_S	::=	#x9 | #xA | #xD | #x20
 // Comment	::=	'/*' ( [^*] | '*'+ [^*/] )* '*'* '*/'
 
-import { IRule, Parser as _Parser, IToken } from '..';
-import { findRuleByName } from '../Parser';
+import { IRule, Parser as _Parser, IToken, findRuleByName } from '../Parser';
 
 namespace BNF {
   export const RULES: IRule[] = [


### PR DESCRIPTION
as addressed in #6 

I have tested that with this fix, the rollup won't show those circular dependency warnings.